### PR TITLE
Build outputBufferName in VimHook model

### DIFF
--- a/lib/vim-hook.vim
+++ b/lib/vim-hook.vim
@@ -16,6 +16,7 @@ function! s:VimHook.New(path, event, pattern)
     " which may or may not exist.
     let newVimHook.id = substitute(newVimHook.path, '\v.disabled$', "", "")
     let newVimHook.baseName = get(matchlist(newVimHook.path, '\v[^/]+$'), 0, "")
+    let newVimHook.outputBufferName = substitute(newVimHook.baseName, '\v.disabled$', "", "") . ".output"
 
     let newVimHook.isEnabled = 1
     if newVimHook.path =~ '\v\.disabled$'

--- a/plugin/hooks.vim
+++ b/plugin/hooks.vim
@@ -208,13 +208,12 @@ function! s:executeHookFiles(...)
                     echom "[vim-hooks] Executing hookfile " . vimHook.toString() . " after event " . vimHook.event
                     let splitCommand = vimHook.getOptionValue('bufferoutput.vsplit') ? 'vnew' : 'new'
                     if vimHook.getOptionValue('bufferoutput')
-                        let outputBufferName = vimHook.baseName . ".output"
-                        let winnr = bufwinnr('^' . outputBufferName . '$')
+                        let winnr = bufwinnr('^' . vimHook.outputBufferName . '$')
                         " If window doesn't exist, create a new one using
                         " botright. If it does exist, just go to that
                         " window number using :[n] wincmd w, which would
                         " go to window n.
-                        execute winnr < 0 ? 'botright ' . splitCommand . ' ' . outputBufferName : winnr . 'wincmd w'
+                        execute winnr < 0 ? 'botright ' . splitCommand . ' ' . vimHook.outputBufferName : winnr . 'wincmd w'
                         setlocal buftype=nowrite
                         setlocal bufhidden=wipe
                         setlocal nobuflisted


### PR DESCRIPTION
Agnostic of whether or not the VimHook is currently disabled or not. Uses the baseName property with ".disabled" removed, if it exists.
